### PR TITLE
fix: default simulator fix

### DIFF
--- a/lib/iphone-simulator-common.ts
+++ b/lib/iphone-simulator-common.ts
@@ -46,9 +46,9 @@ export function getInstalledApplications(deviceId: string): IApplication[] {
 export function startSimulator(deviceId: string): void {
 	let simulatorPath = path.resolve(xcode.getPathFromXcodeSelect(), "Applications", "Simulator.app");
 	let args = ["open", simulatorPath];
-        if (deviceId) {
-	    args.push( '--args', '-CurrentDeviceUDID', deviceId)
-        }
+	if (deviceId) {
+		args.push( '--args', '-CurrentDeviceUDID', deviceId)
+	}
 	childProcess.execSync(args.join(" "));
 }
 

--- a/lib/iphone-simulator-common.ts
+++ b/lib/iphone-simulator-common.ts
@@ -45,7 +45,10 @@ export function getInstalledApplications(deviceId: string): IApplication[] {
 
 export function startSimulator(deviceId: string): void {
 	let simulatorPath = path.resolve(xcode.getPathFromXcodeSelect(), "Applications", "Simulator.app");
-	let args = ["open", simulatorPath, '--args', '-CurrentDeviceUDID', deviceId];
+	let args = ["open", simulatorPath];
+        if (deviceId) {
+	    args.push( '--args', '-CurrentDeviceUDID', deviceId)
+        }
 	childProcess.execSync(args.join(" "));
 }
 

--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -276,15 +276,13 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 			await this.verifyDevice(options.device);
 		}
 
-		device = device || await this.getDeviceToRun(options);
-
 		// In case the id is undefined, skip verification - we'll start default simulator.
 		if (device && device.id) {
 			await this.verifyDevice(device);
 		}
 
-		if (!device || !device.runtimeVersion || !device.fullId) {
-			device = await this.getDeviceToRun(options, device);
+		if (device && (!device.runtimeVersion || !device.fullId)) {
+			device = null;
 		}
 
 		if (!this.isDeviceBooted(device)) {
@@ -298,10 +296,10 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 				}
 				this.simctl.boot(device.id);
 			} else {
-				common.startSimulator(device.id);
+				common.startSimulator(device && device.id);
 			}
 
-			common.startSimulator(device.id);
+			common.startSimulator(device && device.id);
 			// startSimulaltor doesn't always finish immediately, and the subsequent
 			// install fails since the simulator is not running.
 			// Give it some time to start before we attempt installing.

--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -285,7 +285,7 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 			device = null;
 		}
 
-		if (!this.isDeviceBooted(device)) {
+		if (!device || !this.isDeviceBooted(device)) {
 			const isSimulatorAppRunning = this.isSimulatorAppRunning();
 			const haveBootedDevices = this.haveBootedDevices();
 


### PR DESCRIPTION
this fix let the XCode simulator choose the default simulator to run. 
Which is the last state of the simulator app. (can even be multiple simulators)
Before that it was always choosing the same simulator. 
We now have the same behavior as the simulator app which brings a much better user experience ( imho)