### PR TITLE
fix: ignore non-zero exit code from simctl terminate

### DIFF
--- a/lib/iphone-simulator-xcode-simctl.ts
+++ b/lib/iphone-simulator-xcode-simctl.ts
@@ -134,9 +134,16 @@ export class XCodeSimctlSimulator extends IPhoneSimulatorNameGetter implements I
 				}
 			}
 		} catch (e) {
+			// ingore
 		}
 
-		await this.simctl.terminate(deviceId, appIdentifier);
+		try {
+			await this.simctl.terminate(deviceId, appIdentifier);
+		} catch (e) {
+			// sometimes simctl can fail and return a non-zero exit code
+			// in most cases we should be fine to ignore it and continue
+			// todo: find cases where this may break things down the line
+		}
 		utils.sleep(0.5);
 		
 		delete XCodeSimctlSimulator.stoppingApps[appKey];


### PR DESCRIPTION
This fixes a case where `xcrun simctl terminate XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX org.nativescript.app` returns a non-zero exit code peventing the CLI from restarting the app.

Sample log when this occurs:
```
Restarting application on device XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX...
Error while trying to start application org.nativescript.app on device XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX. Error is: Command xcrun with arguments simctl terminate XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX org.nativescript.app failed with exit code 3. Error output:
 objc[61078]: Class AMSupportURLConnectionDelegate is implemented in both /usr/lib/libamsupport.dylib (0x21f3b3678) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x1059202c8). One of the two will be used. Which one is undefined.
objc[61078]: Class AMSupportURLSession is implemented in both /usr/lib/libamsupport.dylib (0x21f3b36c8) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x105920318). One of the two will be used. Which one is undefined.
An error was encountered processing the command (domain=NSPOSIXErrorDomain, code=3):
Application termination failed.
FBSSystemService reported failure without an error, possibly because the app is not currently running.

Unable to start application org.nativescript.app on device XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX. Try starting it manually.
```

With this fix, the exit code is ignored, and we assume everything worked and will continue. In most cases this should be fine, since the next step is usually to start the app - which if is successful - we're all good, and if it fails, the CLI will print the error anyways.